### PR TITLE
Use tmux 2.1 syntax for mouse mode options

### DIFF
--- a/files/default/tmux.conf
+++ b/files/default/tmux.conf
@@ -9,10 +9,7 @@ bind-key l select-pane -R
 set-option -g default-terminal "screen-256color"
 
 # Enable mouse support (works in iTerm)
-set-window-option -g mode-mouse on
-set-option -g mouse-select-pane on
-set-option -g mouse-resize-pane on
-set-option -g mouse-select-window on
+set-option -g mouse on
 
 # scrollback buffer size increase
 set -g history-limit 500000


### PR DESCRIPTION
Signed-off-by: Tyson McNulty <tmcnulty@pivotal.io>