### PR TITLE
Use `be_truthy` matcher instead of `be_true`

### DIFF
--- a/spec/integration/cookbook_spec.rb
+++ b/spec/integration/cookbook_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'sprout-vim' do
   end
 
   it 'installs MacVim, adds the .vim directory, and installs tmux' do
-    expect(system('soloist')).to be_true
+    expect(system('soloist')).to be_truthy
 
     expect(File).to exist(brew_installed_mvim)
     expect(File).to exist(brew_installed_tmux)


### PR DESCRIPTION
Fix for https://github.com/pivotal-sprout/sprout-vim/issues/8
